### PR TITLE
Fix mutable_joint param name

### DIFF
--- a/ind_cal_multi_camera/launch/calibrate_from_images.launch
+++ b/ind_cal_multi_camera/launch/calibrate_from_images.launch
@@ -38,7 +38,7 @@
 
    <!-- Launch mutable joint state publisher for calibratable transforms -->
    <node  name="tower1_camera_locs" pkg="industrial_extrinsic_cal" type="mutable_joint_state_publisher" >
-       <param name="mutableJointStateYamlFile" value="$(find ind_cal_multi_camera)/yaml/towers_mutable_joint_states.yaml" />
+       <param name="mutable_joint_state_yaml_file" value="$(find ind_cal_multi_camera)/yaml/towers_mutable_joint_states.yaml" />
        <remap from="mutable_joint_states" to="$(arg robot1)/joint_states" />
    </node>
 

--- a/ind_cal_multi_camera/launch/kinect_cal.launch
+++ b/ind_cal_multi_camera/launch/kinect_cal.launch
@@ -74,10 +74,6 @@
   <arg name="hw_registered_processing"        default="false" unless="$(arg depth_registration)" />
   <arg name="sw_registered_processing"        default="true" unless="$(arg depth_registration)" />
 
-  <!-- Machine -->
-  <machine name="localhost" address="localhost" env-loader="/opt/ros/hydro/env.sh"/>
-  <arg name="machine"          default="localhost" />
-
   <!-- Disable bond topics by default -->
   <arg name="respawn" default="false" />
   <arg name="bond" default="false" />
@@ -112,7 +108,6 @@
 	  <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
 	    <arg name="name" value="$(arg manager)" />
 	    <arg name="debug" value="$(arg debug)" />
-	    <arg name="machine" value="$(arg machine)" />
 	    <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
 	  </include>
 


### PR DESCRIPTION
Wrong param name since: 
https://github.com/ros-industrial/industrial_calibration/commit/256cf63db8056b70a9aecd3cfa3b04aa05745450#diff-0b60fbad93b4bf11238d10424c6cd6e5
