### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/ind_cal_multi_camera/launch/calibrate_from_images.launch
+++ b/ind_cal_multi_camera/launch/calibrate_from_images.launch
@@ -25,7 +25,7 @@
    </node> 
 
    <!-- Load the xacro file of the tower and cameras onto the parameter server as a robot description -->
-   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro.py $(arg tower1_model)" />
+   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro --inorder $(arg tower1_model)" />
    <param name="use_gui" value="$(arg gui)" />
 
    <!-- Launch robot state publishers for both towers -->

--- a/ind_cal_multi_camera/launch/camera_scene_cal.launch
+++ b/ind_cal_multi_camera/launch/camera_scene_cal.launch
@@ -60,7 +60,7 @@
    </node> 
 
    <!-- Load the xacro file of the tower and cameras onto the parameter server as a robot description -->
-   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro.py $(arg xacro_model)" />
+   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro --inorder $(arg xacro_model)" />
    <param name="use_gui" value="$(arg gui)" />
 
    <!-- Launch robot state publishers for scene -->

--- a/ind_cal_multi_camera/urdf/gen_urdf.sh
+++ b/ind_cal_multi_camera/urdf/gen_urdf.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-rosrun xacro xacro.py camera_scene.xacro > camera_scene.urdf
+rosrun xacro xacro --inorder camera_scene.xacro > camera_scene.urdf
 


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic